### PR TITLE
Increase maximum temperature limit to 30.0

### DIFF
--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -64,7 +64,7 @@ DEFAULT_TIMER_DURATION: Final = 1800
 
 # Temperature limits
 MIN_TEMP: Final = 5.0
-MAX_TEMP: Final = 25.0
+MAX_TEMP: Final = 30.0
 TEMP_STEP: Final = 0.5
 
 # Battery states


### PR DESCRIPTION
This PR fixes an issue where the maximum target temperature exposed by the integration was incorrectly limited to 25°C, while Tado X devices and the official Tado app allow temperatures up to 30°C.

### What’s changed
- Updated the MAX_TEMP constant from 25.0°C to 30.0°C
- The climate entity now correctly reflects the actual temperature range supported by Tado X devices
- Home Assistant no longer clamps values above 25°C