### PR TITLE
French translation added

### DIFF
--- a/custom_components/tado_x/translations/fr.json
+++ b/custom_components/tado_x/translations/fr.json
@@ -153,13 +153,13 @@
         "name": "Température de l'appareil"
       },
       "api_calls_today": {
-        "name": "Nombre d'appels à l'API aujourd'hui"
+        "name": "Appels API aujourd'hui"
       },
       "api_quota_remaining": {
-        "name": "Quota restant d'appels à l'API"
+        "name": "Quota API restant"
       },
       "api_quota_limit": {
-        "name": "Quota maximum d'appels à l'API"
+        "name": "Limite de quota API"
       },
       "api_usage_percentage": {
         "name": "Utilisation de l'API"


### PR DESCRIPTION
This pull request is about the full french translation to the integration based on french used in France. 

Could be later improved with other contributors where we could separate fr.json into multiple locales as fr_FR.json or fr_CA.json and/or keep the fr.json file for "generic french"