### PR TITLE
DHW Control 

### DIFF
--- a/custom_components/tado_x/__init__.py
+++ b/custom_components/tado_x/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_API_RESET_TIME,
     CONF_ENABLE_AIR_COMFORT,
     CONF_ENABLE_FLOW_TEMP,
+    CONF_ENABLE_HOT_WATER,
     CONF_ENABLE_MOBILE_DEVICES,
     CONF_ENABLE_RUNNING_TIMES,
     CONF_ENABLE_WEATHER,
@@ -197,6 +198,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     enable_air_comfort = entry.data.get(CONF_ENABLE_AIR_COMFORT, default_features)
     enable_running_times = entry.data.get(CONF_ENABLE_RUNNING_TIMES, default_features)
     enable_flow_temp = entry.data.get(CONF_ENABLE_FLOW_TEMP, default_features)
+    enable_hot_water = entry.data.get(CONF_ENABLE_HOT_WATER, default_features)
 
     # Create coordinator
     coordinator = TadoXDataUpdateCoordinator(
@@ -211,6 +213,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         enable_air_comfort=enable_air_comfort,
         enable_running_times=enable_running_times,
         enable_flow_temp=enable_flow_temp,
+        enable_hot_water=enable_hot_water,
     )
 
     # Fetch initial data

--- a/custom_components/tado_x/api.py
+++ b/custom_components/tado_x/api.py
@@ -856,6 +856,27 @@ class TadoXApi:
             json_data={"autoAdaptation": {"enabled": enabled}},
         )
 
+    async def get_domestic_hot_water_state(self) -> dict[str, Any]:
+        """Get the status of domestic hot water.
+
+        Returns:
+            Status information including:
+            {
+                "status": "OFF" | "SCHEDULE_OFF" |"SCHEDULE_ON" | "BOOST",
+                "nextStateChange": "2026-02-14T16:00:00Z",
+                "setpoint": null,
+                "setpointConstraints": null
+            }
+        """
+        if not self._home_id:
+            raise TadoXApiError("Home ID not set")
+
+        result = await self._request(
+            "GET",
+            f"{TADO_HOPS_API_URL}/homes/{self._home_id}/programmer/domesticHotWater/state",
+        )
+        return result if isinstance(result, dict) else {}
+
     async def boost_domestic_hot_water(self) -> None:
         """Boost domestic hot water."""
         if not self._home_id:

--- a/custom_components/tado_x/api.py
+++ b/custom_components/tado_x/api.py
@@ -855,3 +855,37 @@ class TadoXApi:
             f"{TADO_HOPS_API_URL}/homes/{self._home_id}/settings/flowTemperatureOptimization",
             json_data={"autoAdaptation": {"enabled": enabled}},
         )
+
+    async def boost_domestic_hot_water(self) -> None:
+        """Boost domestic hot water."""
+        if not self._home_id:
+            raise TadoXApiError("Home ID not set")
+
+        await self._request(
+            "POST",
+            f"{TADO_HOPS_API_URL}/homes/{self._home_id}/programmer/domesticHotWater/boost",
+            json_data={ "boost": "ON" },
+        )
+
+    async def disable_domestic_hot_water(self) -> None:
+        """Turn off domestic hot water."""
+        if not self._home_id:
+            raise TadoXApiError("Home ID not set")
+
+        await self._request(
+            "POST",
+            f"{TADO_HOPS_API_URL}/homes/{self._home_id}/programmer/domesticHotWater/boost",
+            json_data={ "boost": "OFF" },
+        )
+        
+    async def resume_domestic_hot_water_schedule(self) -> None:
+        """Resume the schedule for domestic hot water."""
+        if not self._home_id:
+            raise TadoXApiError("Home ID not set")
+
+        await self._request(
+            "POST",
+            f"{TADO_HOPS_API_URL}/homes/{self._home_id}/programmer/domesticHotWater/resumeSchedule",
+        )
+    
+

--- a/custom_components/tado_x/button.py
+++ b/custom_components/tado_x/button.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, FEATURE_ENTITY_MAP
 from .coordinator import TadoXDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,6 +79,48 @@ async def async_setup_entry(
     ]
 
     async_add_entities(entities)
+
+    # Set initial disabled_by state based on feature flags
+    from homeassistant.helpers import entity_registry as er
+    entity_registry = er.async_get(hass)
+    
+    # Disable entities based on feature flags
+    for entity_id, entity_entry in list(entity_registry.entities.items()):
+        # Only process Tado X button entities
+        if entity_entry.platform != DOMAIN or entity_entry.domain != "button":
+            continue
+        
+        if not entity_entry.unique_id:
+            continue
+        
+        # Check if this entity matches a disabled feature
+        should_be_disabled = False
+        for feature_flag, entity_keys in FEATURE_ENTITY_MAP.items():
+            feature_enabled = getattr(coordinator, feature_flag, False)
+            
+            # Check if entity_key matches any of the disabled feature's keys
+            for entity_key in entity_keys:
+                if entity_entry.unique_id.endswith(f"_{entity_key}"):
+                    if not feature_enabled:
+                        should_be_disabled = True
+                    break
+            
+            if should_be_disabled:
+                break
+        
+        # Update disabled state
+        if should_be_disabled:
+            entity_registry.async_update_entity(
+                entity_id,
+                disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+            )
+        else:
+            # Make sure it's enabled if the feature is on
+            if entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION:
+                entity_registry.async_update_entity(
+                    entity_id,
+                    disabled_by=None,
+                )
 
 
 class TadoXButton(CoordinatorEntity[TadoXDataUpdateCoordinator], ButtonEntity):

--- a/custom_components/tado_x/button.py
+++ b/custom_components/tado_x/button.py
@@ -44,6 +44,24 @@ BUTTON_DESCRIPTIONS: tuple[TadoXButtonEntityDescription, ...] = (
         icon="mdi:calendar-clock",
         press_fn=lambda coordinator: coordinator.api.resume_all_schedules(),
     ),
+    TadoXButtonEntityDescription(
+        key="boost_hot_water",
+        translation_key="boost_hot_water",
+        icon="mdi:fire",
+        press_fn=lambda coordinator: coordinator.api.boost_domestic_hot_water(),
+    ),
+    TadoXButtonEntityDescription(
+        key="disable_hot_water",
+        translation_key="disable_hot_water",
+        icon="mdi:power-off",
+        press_fn=lambda coordinator: coordinator.api.disable_domestic_hot_water(),
+    ),
+    TadoXButtonEntityDescription(
+        key="resume_hot_water_schedule",
+        translation_key="resume_hot_water_schedule",
+        icon="mdi:calendar-clock",
+        press_fn=lambda coordinator: coordinator.api.resume_domestic_hot_water_schedule(),
+    ),
 )
 
 

--- a/custom_components/tado_x/config_flow.py
+++ b/custom_components/tado_x/config_flow.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_TOKEN_EXPIRY,
     DOMAIN,
+    FEATURE_ENTITY_MAP,
     SCAN_INTERVAL_AUTO_ASSIST,
     SCAN_INTERVAL_FREE_TIER,
 )
@@ -259,6 +260,37 @@ class TadoXConfigFlow(ConfigFlow, domain=DOMAIN):
 class TadoXOptionsFlow(OptionsFlow):
     """Handle Tado X options."""
 
+    async def _update_entity_states(
+        self, coordinator: Any
+    ) -> None:
+        """Update entity enabled/disabled states based on feature flags."""
+        from homeassistant.helpers import entity_registry as er
+        
+        entity_registry = er.async_get(self.hass)
+        
+        # Check each feature and its corresponding entities
+        for feature_flag, entity_keys in FEATURE_ENTITY_MAP.items():
+            feature_enabled = getattr(coordinator, feature_flag, False)
+            
+            # Find all entities matching this feature
+            # entity_registry.entities is a dict with entity_id as key
+            for entity_id, entity_entry in entity_registry.entities.items():
+                # Only process Tado X sensor or button entities
+                if entity_entry.platform != DOMAIN or entity_entry.domain not in ("sensor", "button"):
+                    continue
+                
+                # Check if this entity's unique_id ends with the feature key
+                if entity_entry.unique_id:
+                    # unique_id format is like: "123456_dhw_state" for sensors or "123456_boost_hot_water" for buttons
+                    for entity_key in entity_keys:
+                        if entity_entry.unique_id.endswith(f"_{entity_key}"):
+                            # Update the entity's disabled_by state
+                            entity_registry.async_update_entity(
+                                entity_id,
+                                disabled_by=None if feature_enabled else er.RegistryEntryDisabler.INTEGRATION,
+                            )
+                            break
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -313,6 +345,9 @@ class TadoXOptionsFlow(OptionsFlow):
                 coordinator.enable_running_times = enable_running_times
                 coordinator.enable_flow_temp = enable_flow_temp
                 coordinator.enable_hot_water = enable_hot_water
+
+                # Handle entity state changes when features are toggled
+                await self._update_entity_states(coordinator)
 
             return self.async_create_entry(title="", data={})
 

--- a/custom_components/tado_x/config_flow.py
+++ b/custom_components/tado_x/config_flow.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_ACCESS_TOKEN,
     CONF_ENABLE_AIR_COMFORT,
     CONF_ENABLE_FLOW_TEMP,
+    CONF_ENABLE_HOT_WATER,
     CONF_ENABLE_MOBILE_DEVICES,
     CONF_ENABLE_RUNNING_TIMES,
     CONF_ENABLE_WEATHER,
@@ -272,6 +273,7 @@ class TadoXOptionsFlow(OptionsFlow):
             enable_air_comfort = user_input.get(CONF_ENABLE_AIR_COMFORT, has_auto_assist)
             enable_running_times = user_input.get(CONF_ENABLE_RUNNING_TIMES, has_auto_assist)
             enable_flow_temp = user_input.get(CONF_ENABLE_FLOW_TEMP, has_auto_assist)
+            enable_hot_water = user_input.get(CONF_ENABLE_HOT_WATER, has_auto_assist)
 
             # Determine scan interval: custom if set, otherwise based on tier
             if custom_interval and custom_interval > 0:
@@ -292,6 +294,7 @@ class TadoXOptionsFlow(OptionsFlow):
                 CONF_ENABLE_AIR_COMFORT: enable_air_comfort,
                 CONF_ENABLE_RUNNING_TIMES: enable_running_times,
                 CONF_ENABLE_FLOW_TEMP: enable_flow_temp,
+                CONF_ENABLE_HOT_WATER: enable_hot_water,
             }
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
@@ -309,6 +312,7 @@ class TadoXOptionsFlow(OptionsFlow):
                 coordinator.enable_air_comfort = enable_air_comfort
                 coordinator.enable_running_times = enable_running_times
                 coordinator.enable_flow_temp = enable_flow_temp
+                coordinator.enable_hot_water = enable_hot_water
 
             return self.async_create_entry(title="", data={})
 
@@ -323,6 +327,7 @@ class TadoXOptionsFlow(OptionsFlow):
         current_enable_air_comfort = self.config_entry.data.get(CONF_ENABLE_AIR_COMFORT, default_features)
         current_enable_running_times = self.config_entry.data.get(CONF_ENABLE_RUNNING_TIMES, default_features)
         current_enable_flow_temp = self.config_entry.data.get(CONF_ENABLE_FLOW_TEMP, default_features)
+        current_enable_hot_water = self.config_entry.data.get(CONF_ENABLE_HOT_WATER, default_features)
 
         # Suggested intervals based on tier
         default_interval = (
@@ -361,6 +366,10 @@ class TadoXOptionsFlow(OptionsFlow):
                     vol.Required(
                         CONF_ENABLE_FLOW_TEMP,
                         default=current_enable_flow_temp,
+                    ): bool,
+                    vol.Required(
+                        CONF_ENABLE_HOT_WATER,
+                        default=current_enable_hot_water,
                     ): bool,
                 }
             ),

--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -83,7 +83,7 @@ PLATFORMS: Final = ["climate", "sensor", "binary_sensor", "switch", "button", "d
 # Feature to entity key mapping for sensor/button platforms
 # This maps feature flags to the corresponding entity keys that should be enabled/disabled based on the flag
 FEATURE_ENTITY_MAP: Final = {
-    "enable_hot_water": ["dhw_state", "boost_hot_water", "disable_hot_water", "resume_hot_water_schedule"],
+    "enable_hot_water": ["dhw_state", "dhw_mode", "boost_hot_water", "disable_hot_water", "resume_hot_water_schedule"],
     "enable_weather": ["outdoor_temperature", "solar_intensity", "weather_state"],
     "enable_running_times": ["heating_time_today"],
     "enable_air_comfort": ["air_freshness", "comfort_level"],

--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -79,3 +79,12 @@ CONNECTION_STATE_DISCONNECTED: Final = "DISCONNECTED"
 
 # Platforms
 PLATFORMS: Final = ["climate", "sensor", "binary_sensor", "switch", "button", "device_tracker", "select", "number"]
+
+# Feature to entity key mapping for sensor/button platforms
+# This maps feature flags to the corresponding entity keys that should be enabled/disabled based on the flag
+FEATURE_ENTITY_MAP: Final = {
+    "enable_hot_water": ["dhw_state", "boost_hot_water", "disable_hot_water", "resume_hot_water_schedule"],
+    "enable_weather": ["outdoor_temperature", "solar_intensity", "weather_state"],
+    "enable_running_times": ["heating_time_today"],
+    "enable_air_comfort": ["air_freshness", "comfort_level"],
+}

--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -44,6 +44,7 @@ CONF_ENABLE_MOBILE_DEVICES: Final = "enable_mobile_devices"
 CONF_ENABLE_AIR_COMFORT: Final = "enable_air_comfort"
 CONF_ENABLE_RUNNING_TIMES: Final = "enable_running_times"
 CONF_ENABLE_FLOW_TEMP: Final = "enable_flow_temp"
+CONF_ENABLE_HOT_WATER: Final = "enable_hot_water"
 
 # Base API calls (required): get_rooms, get_rooms_and_devices, get_home_state
 API_CALLS_BASE: Final = 3

--- a/custom_components/tado_x/coordinator.py
+++ b/custom_components/tado_x/coordinator.py
@@ -125,6 +125,8 @@ class TadoXData:
     flow_temp_auto_adaptation: bool = False
     flow_temp_auto_value: int | None = None
     has_flow_temp_control: bool = False
+    # Domestic hot water state (e.g., OFF, SCHEDULE_ON, SCHEDULE_OFF, BOOST)
+    dhw_state: str | None = None
 
 
 class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
@@ -216,6 +218,10 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
             presence = home_state.get("presence")
             presence_locked = home_state.get("presenceLocked", False)
 
+            # Get domestic hot water state 
+            dhw_state_response = await self.api.get_domestic_hot_water_state()
+            dhw_state = dhw_state_response.get("state")
+            
             # Get weather data (optional)
             weather = None
             if self.enable_weather:
@@ -242,6 +248,7 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
                 presence=presence,
                 presence_locked=presence_locked,
                 weather=weather,
+                dhw_state=dhw_state
             )
 
             # Process rooms and devices

--- a/custom_components/tado_x/coordinator.py
+++ b/custom_components/tado_x/coordinator.py
@@ -145,6 +145,7 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
         enable_air_comfort: bool = True,
         enable_running_times: bool = True,
         enable_flow_temp: bool = True,
+        enable_hot_water: bool = True,
     ) -> None:
         """Initialize the coordinator."""
         # Determine scan interval based on subscription tier if not explicitly set
@@ -173,6 +174,7 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
         self.enable_air_comfort = enable_air_comfort
         self.enable_running_times = enable_running_times
         self.enable_flow_temp = enable_flow_temp
+        self.enable_hot_water = enable_hot_water
 
         _LOGGER.info(
             "Tado X coordinator initialized with %d second update interval (%s tier)",
@@ -180,8 +182,8 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
             "Auto-Assist" if api.has_auto_assist else "Free"
         )
         _LOGGER.info(
-            "Optional features - Weather: %s, Mobile devices: %s, Air comfort: %s, Running times: %s, Flow temp: %s",
-            enable_weather, enable_mobile_devices, enable_air_comfort, enable_running_times, enable_flow_temp
+            "Optional features - Weather: %s, Mobile devices: %s, Air comfort: %s, Running times: %s, Flow temp: %s, Hot water: %s",
+            enable_weather, enable_mobile_devices, enable_air_comfort, enable_running_times, enable_flow_temp, enable_hot_water
         )
 
     def update_scan_interval(self, new_interval: int) -> None:
@@ -202,6 +204,8 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
             calls += 1
         if self.enable_running_times:
             calls += 1
+        if self.enable_hot_water:
+            calls += 1
         return calls
 
     async def _async_update_data(self) -> TadoXData:
@@ -218,9 +222,11 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
             presence = home_state.get("presence")
             presence_locked = home_state.get("presenceLocked", False)
 
-            # Get domestic hot water state 
-            dhw_state_response = await self.api.get_domestic_hot_water_state()
-            dhw_state = dhw_state_response.get("state")
+            # Get domestic hot water state (optional)
+            dhw_state = None
+            if self.enable_hot_water:
+                dhw_state_response = await self.api.get_domestic_hot_water_state()
+                dhw_state = dhw_state_response.get("state")
             
             # Get weather data (optional)
             weather = None

--- a/custom_components/tado_x/select.py
+++ b/custom_components/tado_x/select.py
@@ -2,16 +2,18 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.select import SelectEntity
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, FEATURE_ENTITY_MAP
 from .coordinator import TadoXDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,6 +25,17 @@ PRESENCE_AUTO = "auto"
 
 PRESENCE_OPTIONS = [PRESENCE_HOME, PRESENCE_AWAY, PRESENCE_AUTO]
 
+# Domestic hot water modes
+DHW_OFF = "OFF"
+DHW_SCHEDULE = "SCHEDULE"
+DHW_BOOST = "BOOST"
+
+DHW_OPTIONS = [DHW_OFF, DHW_SCHEDULE, DHW_BOOST]
+
+
+@dataclass(frozen=True, kw_only=True)
+class TadoXSelectEntityDescription(SelectEntityDescription):
+    """Describes a Tado X select entity."""
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -33,24 +46,76 @@ async def async_setup_entry(
     coordinator: TadoXDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities: list[SelectEntity] = [
-        TadoXPresenceSelect(coordinator),
+        TadoXPresenceSelect(coordinator, TadoXSelectEntityDescription(
+            key="presence_mode",
+            translation_key="presence_mode",
+            icon="mdi:home-account",
+            options=PRESENCE_OPTIONS,
+        )),
+        TadoXDhwModeSelect(coordinator, TadoXSelectEntityDescription(
+            key="dhw_mode",
+            translation_key="dhw_mode",
+            icon="mdi:water-boiler",
+            options=DHW_OPTIONS,
+        )),
     ]
 
     async_add_entities(entities)
+
+    # Update entity enabled/disabled state based on feature flags
+    entity_registry = er.async_get(hass)
+    for entity_id, entity_entry in entity_registry.entities.items():
+        if entity_entry.platform != DOMAIN:
+            continue
+
+        if not entity_entry.unique_id:
+            continue
+
+        # Check if this entity matches a disabled feature
+        should_be_disabled = False
+        for feature_flag, entity_keys in FEATURE_ENTITY_MAP.items():
+            feature_enabled = getattr(coordinator, feature_flag, False)
+
+            # Check if entity_key matches any of the disabled feature's keys
+            for entity_key in entity_keys:
+                if entity_entry.unique_id.endswith(f"_{entity_key}"):
+                    if not feature_enabled:
+                        should_be_disabled = True
+                    break
+
+            if should_be_disabled:
+                break
+
+        # Update disabled state
+        if should_be_disabled:
+            entity_registry.async_update_entity(
+                entity_id,
+                disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+            )
+        else:
+            # Make sure it's enabled if the feature is on
+            if entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION:
+                entity_registry.async_update_entity(
+                    entity_id,
+                    disabled_by=None,
+                )
 
 
 class TadoXPresenceSelect(CoordinatorEntity[TadoXDataUpdateCoordinator], SelectEntity):
     """Select entity for Tado X home presence mode."""
 
     _attr_has_entity_name = True
-    _attr_translation_key = "presence_mode"
-    _attr_icon = "mdi:home-account"
-    _attr_options = PRESENCE_OPTIONS
+    entity_description: TadoXSelectEntityDescription
 
-    def __init__(self, coordinator: TadoXDataUpdateCoordinator) -> None:
+    def __init__(
+        self,
+        coordinator: TadoXDataUpdateCoordinator,
+        description: TadoXSelectEntityDescription,
+    ) -> None:
         """Initialize the presence select entity."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.home_id}_presence_mode"
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.home_id}_{description.key}"
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -93,6 +158,68 @@ class TadoXPresenceSelect(CoordinatorEntity[TadoXDataUpdateCoordinator], SelectE
             await self.coordinator.async_request_refresh()
         except Exception as err:
             _LOGGER.error("Failed to set presence mode to %s: %s", option, err)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class TadoXDhwModeSelect(CoordinatorEntity[TadoXDataUpdateCoordinator], SelectEntity):
+    """Select entity for Tado X domestic hot water mode."""
+
+    _attr_has_entity_name = True
+    entity_description: TadoXSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: TadoXDataUpdateCoordinator,
+        description: TadoXSelectEntityDescription,
+    ) -> None:
+        """Initialize the domestic hot water select entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.home_id}_{description.key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the home."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self.coordinator.home_id))},
+            name=self.coordinator.home_name,
+            manufacturer="Tado",
+            model="Tado X Home",
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current domestic hot water mode."""
+        data = self.coordinator.data
+        if not data:
+            return None
+
+        if data.dhw_state in ("SCHEDULE_ON", "SCHEDULE_OFF"):
+            return DHW_SCHEDULE
+        if data.dhw_state in DHW_OPTIONS:
+            return data.dhw_state
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the domestic hot water mode."""
+        try:
+            if option == DHW_BOOST:
+                await self.coordinator.api.boost_domestic_hot_water()
+            elif option == DHW_OFF:
+                await self.coordinator.api.disable_domestic_hot_water()
+            elif option == DHW_SCHEDULE:
+                await self.coordinator.api.resume_domestic_hot_water_schedule()
+            else:
+                _LOGGER.error("Invalid domestic hot water mode selected: %s", option)
+                return
+
+            await self.coordinator.async_request_refresh()
+        except Exception as err:
+            _LOGGER.error("Failed to set domestic hot water mode to %s: %s", option, err)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/tado_x/sensor.py
+++ b/custom_components/tado_x/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import API_QUOTA_FREE_TIER, API_QUOTA_PREMIUM, DOMAIN
+from .const import API_QUOTA_FREE_TIER, API_QUOTA_PREMIUM, DOMAIN, FEATURE_ENTITY_MAP
 from .coordinator import (
     TadoXData,
     TadoXDataUpdateCoordinator,
@@ -339,9 +339,6 @@ async def async_setup_entry(
 
     # Add home-level sensors (API monitoring)
     for description in HOME_SENSORS:
-        # Skip dhw_state if hot water feature is disabled
-        if description.key == "dhw_state" and not coordinator.enable_hot_water:
-            continue
         entities.append(TadoXHomeSensor(coordinator, description))
 
     # Add weather sensors (only if feature is enabled)
@@ -376,6 +373,48 @@ async def async_setup_entry(
                 entities.append(TadoXAirComfortSensor(coordinator, room_id, description))
 
     async_add_entities(entities)
+
+    # Set initial disabled_by state based on feature flags
+    from homeassistant.helpers import entity_registry as er
+    entity_registry = er.async_get(hass)
+    
+    # Disable entities based on feature flags
+    for entity_id, entity_entry in list(entity_registry.entities.items()):
+        # Only process Tado X sensor entities
+        if entity_entry.platform != DOMAIN or entity_entry.domain != "sensor":
+            continue
+        
+        if not entity_entry.unique_id:
+            continue
+        
+        # Check if this entity matches a disabled feature
+        should_be_disabled = False
+        for feature_flag, entity_keys in FEATURE_ENTITY_MAP.items():
+            feature_enabled = getattr(coordinator, feature_flag, False)
+            
+            # Check if entity_key matches any of the disabled feature's keys
+            for entity_key in entity_keys:
+                if entity_entry.unique_id.endswith(f"_{entity_key}"):
+                    if not feature_enabled:
+                        should_be_disabled = True
+                    break
+            
+            if should_be_disabled:
+                break
+        
+        # Update disabled state
+        if should_be_disabled:
+            entity_registry.async_update_entity(
+                entity_id,
+                disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+            )
+        else:
+            # Make sure it's enabled if the feature is on
+            if entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION:
+                entity_registry.async_update_entity(
+                    entity_id,
+                    disabled_by=None,
+                )
 
 
 class TadoXHomeSensor(CoordinatorEntity[TadoXDataUpdateCoordinator], SensorEntity):

--- a/custom_components/tado_x/sensor.py
+++ b/custom_components/tado_x/sensor.py
@@ -339,6 +339,9 @@ async def async_setup_entry(
 
     # Add home-level sensors (API monitoring)
     for description in HOME_SENSORS:
+        # Skip dhw_state if hot water feature is disabled
+        if description.key == "dhw_state" and not coordinator.enable_hot_water:
+            continue
         entities.append(TadoXHomeSensor(coordinator, description))
 
     # Add weather sensors (only if feature is enabled)

--- a/custom_components/tado_x/sensor.py
+++ b/custom_components/tado_x/sensor.py
@@ -204,6 +204,10 @@ def _get_presence_mode(data: TadoXData) -> str:
         return "MANUAL"
     return "AUTO"
 
+def _get_domestic_hot_water_state(data: TadoXData) -> str:
+    """Get the state of DHW (OFF, SCHEDULE_OFF, SCHEDULE_ON, BOOST)."""
+    return data.dhw_state;
+
 
 HOME_SENSORS: tuple[TadoXHomeSensorEntityDescription, ...] = (
     TadoXHomeSensorEntityDescription(
@@ -265,6 +269,14 @@ HOME_SENSORS: tuple[TadoXHomeSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENUM,
         options=["AUTO", "MANUAL"],
         value_fn=_get_presence_mode,
+    ),
+    TadoXHomeSensorEntityDescription(
+        key="dhw_state",
+        translation_key="dhw_state",
+        icon="mdi:water-boiler",
+        device_class=SensorDeviceClass.ENUM,
+        options=["OFF", "SCHEDULE_OFF", "SCHEDULE_ON", "BOOST"],
+        value_fn=_get_domestic_hot_water_state,
     ),
 )
 

--- a/custom_components/tado_x/strings.json
+++ b/custom_components/tado_x/strings.json
@@ -293,6 +293,15 @@
       },
       "resume_schedules": {
         "name": "Resume Schedules"
+      },
+      "boost_hot_water": {
+        "name": "Boost Hot Water"
+      },
+      "disable_hot_water": {
+        "name": "Turn Off Hot Water"
+      },
+      "resume_hot_water_schedule": {
+        "name": "Resume Hot Water Schedule"
       }
     },
     "select": {

--- a/custom_components/tado_x/strings.json
+++ b/custom_components/tado_x/strings.json
@@ -50,7 +50,8 @@
           "enable_mobile_devices": "Enable mobile device tracking",
           "enable_air_comfort": "Enable air comfort sensors",
           "enable_running_times": "Enable heating time sensors",
-          "enable_flow_temp": "Enable flow temperature control"
+          "enable_flow_temp": "Enable flow temperature control",
+          "enable_hot_water": "Enable hot water sensor"
         },
         "data_description": {
           "has_auto_assist": "Enable this if you have an Auto-Assist subscription. This will automatically adjust the update interval.",
@@ -59,7 +60,8 @@
           "enable_mobile_devices": "Enables device trackers for mobile phones with geofencing. Uses 1 API call per update.",
           "enable_air_comfort": "Enables air freshness and comfort level sensors per room. Uses 1 API call per update.",
           "enable_running_times": "Enables heating time today sensors per room. Uses 1 API call per update.",
-          "enable_flow_temp": "Enables max flow temperature slider and auto-adaptation switch (requires OpenTherm boiler). Uses 1 API call per update."
+          "enable_flow_temp": "Enables max flow temperature slider and auto-adaptation switch (requires OpenTherm boiler). Uses 1 API call per update.",
+          "enable_hot_water": "Enables domestic hot water state sensor. Uses 1 API call per update."
         }
       }
     }

--- a/custom_components/tado_x/strings.json
+++ b/custom_components/tado_x/strings.json
@@ -314,6 +314,14 @@
           "away": "Away",
           "auto": "Auto (Geofencing)"
         }
+      },
+      "dhw_mode": {
+        "name": "Hot Water Mode",
+        "state": {
+          "OFF": "Off",
+          "SCHEDULE": "Schedule",
+          "BOOST": "Boost"
+        }
       }
     },
     "device_tracker": {

--- a/custom_components/tado_x/translations/de.json
+++ b/custom_components/tado_x/translations/de.json
@@ -197,6 +197,15 @@
       "solar_intensity": {
         "name": "Sonnenintensität"
       },
+      "dhw_state": {
+        "name": "Warmwasserzustand",
+        "state": {
+          "OFF": "Aus",
+          "SCHEDULE_OFF": "Zeitplan Aus",
+          "SCHEDULE_ON": "Zeitplan Ein",
+          "BOOST": "Hochfahren"
+        }
+      },
       "weather_state": {
         "name": "Wetterlage",
         "state": {

--- a/custom_components/tado_x/translations/de.json
+++ b/custom_components/tado_x/translations/de.json
@@ -184,13 +184,6 @@
           "AWAY": "Unterwegs"
         }
       },
-      "presence_mode": {
-        "name": "Anwesenheitsmodus",
-        "state": {
-          "MANUAL": "Manuell",
-          "AUTO": "Auto (Geofencing)"
-        }
-      },
       "outdoor_temperature": {
         "name": "Außentemperatur"
       },
@@ -321,6 +314,24 @@
           "locale": {
             "name": "Locale"
           }
+        }
+      }
+    },
+    "select": {
+      "presence_mode": {
+        "name": "Anwesenheitsmodus",
+        "state": {
+          "home": "Zuhause",
+          "away": "Unterwegs",
+          "auto": "Auto (Geofencing)"
+        }
+      },
+      "dhw_mode": {
+        "name": "Warmwasser-Modus",
+        "state": {
+          "OFF": "Aus",
+          "SCHEDULE": "Zeitplan",
+          "BOOST": "Hochfahren"
         }
       }
     }

--- a/custom_components/tado_x/translations/de.json
+++ b/custom_components/tado_x/translations/de.json
@@ -273,6 +273,15 @@
       },
       "resume_schedules": {
         "name": "Zeitplan fortsetzen"
+      },
+      "boost_hot_water": {
+        "name": "Warmwasser steigern"
+      },
+      "disable_hot_water": {
+        "name": "Schalten sie heißes wasser aus"
+      },
+      "resume_hot_water_schedule": {
+        "name": "Warmwasserplan wieder aufnehmen"
       }
     },
     "device_tracker": {

--- a/custom_components/tado_x/translations/en.json
+++ b/custom_components/tado_x/translations/en.json
@@ -188,13 +188,6 @@
           "AWAY": "Away"
         }
       },
-      "presence_mode": {
-        "name": "Presence Mode",
-        "state": {
-          "MANUAL": "Manual",
-          "AUTO": "Auto (Geofencing)"
-        }
-      },
       "outdoor_temperature": {
         "name": "Outdoor Temperature"
       },
@@ -325,6 +318,24 @@
           "locale": {
             "name": "Locale"
           }
+        }
+      }
+    },
+    "select": {
+      "presence_mode": {
+        "name": "Presence Mode",
+        "state": {
+          "home": "Home",
+          "away": "Away",
+          "auto": "Auto (Geofencing)"
+        }
+      },
+      "dhw_mode": {
+        "name": "Hot Water Mode",
+        "state": {
+          "OFF": "Off",
+          "SCHEDULE": "Schedule",
+          "BOOST": "Boost"
         }
       }
     }

--- a/custom_components/tado_x/translations/en.json
+++ b/custom_components/tado_x/translations/en.json
@@ -49,7 +49,9 @@
           "enable_weather": "Enable weather sensors",
           "enable_mobile_devices": "Enable mobile device tracking",
           "enable_air_comfort": "Enable air comfort sensors",
-          "enable_running_times": "Enable heating time sensors"
+          "enable_running_times": "Enable heating time sensors",
+          "enable_flow_temp": "Enable flow temperature control",
+          "enable_hot_water": "Enable hot water sensor"
         },
         "data_description": {
           "has_auto_assist": "Enable this if you have an Auto-Assist subscription. This will automatically adjust the update interval.",
@@ -57,7 +59,9 @@
           "enable_weather": "Enables outdoor temperature, solar intensity, and weather state sensors. Uses 1 API call per update.",
           "enable_mobile_devices": "Enables device trackers for mobile phones with geofencing. Uses 1 API call per update.",
           "enable_air_comfort": "Enables air freshness and comfort level sensors per room. Uses 1 API call per update.",
-          "enable_running_times": "Enables heating time today sensors per room. Uses 1 API call per update."
+          "enable_running_times": "Enables heating time today sensors per room. Uses 1 API call per update.",
+          "enable_flow_temp": "Enables max flow temperature slider and auto-adaptation switch (requires OpenTherm boiler). Uses 1 API call per update.",
+          "enable_hot_water": "Enables domestic hot water state sensor. Uses 1 API call per update."
         }
       }
     }

--- a/custom_components/tado_x/translations/en.json
+++ b/custom_components/tado_x/translations/en.json
@@ -268,6 +268,15 @@
       },
       "resume_schedules": {
         "name": "Resume Schedules"
+      },
+      "boost_hot_water": {
+        "name": "Boost Hot Water"
+      },
+      "disable_hot_water": {
+        "name": "Turn Off Hot Water"
+      },
+      "resume_hot_water_schedule": {
+        "name": "Resume Hot Water Schedule"
       }
     },
     "number": {

--- a/custom_components/tado_x/translations/en.json
+++ b/custom_components/tado_x/translations/en.json
@@ -197,6 +197,15 @@
       "solar_intensity": {
         "name": "Solar Intensity"
       },
+      "dhw_state":{
+        "name": "Hot Water State",
+        "state": {
+          "OFF": "Off",
+          "SCHEDULE_OFF": "Schedule Off",
+          "SCHEDULE_ON": "Schedule On",
+          "BOOST": "Boost"
+        }
+      },
       "weather_state": {
         "name": "Weather State",
         "state": {

--- a/custom_components/tado_x/translations/it.json
+++ b/custom_components/tado_x/translations/it.json
@@ -162,13 +162,6 @@
           "AWAY": "Fuori casa"
         }
       },
-      "presence_mode": {
-        "name": "Modalità presenza",
-        "state": {
-          "MANUAL": "Manuale",
-          "AUTO": "Automatico (Geofencing)"
-        }
-      },
       "outdoor_temperature": { "name": "Temperatura esterna" },
       "solar_intensity": { "name": "Intensità solare" },
       "dhw_state": {
@@ -253,6 +246,24 @@
           "os_version": { "name": "Versione OS" },
           "model": { "name": "Modello" },
           "locale": { "name": "Lingua" }
+        }
+      }
+    },
+    "select": {
+      "presence_mode": {
+        "name": "Modalità presenza",
+        "state": {
+          "home": "Casa",
+          "away": "Fuori casa",
+          "auto": "Auto (Geofencing)"
+        }
+      },
+      "dhw_mode": {
+        "name": "Modalità acqua calda",
+        "state": {
+          "OFF": "Spento",
+          "SCHEDULE": "Programmazione",
+          "BOOST": "Boost"
         }
       }
     }

--- a/custom_components/tado_x/translations/it.json
+++ b/custom_components/tado_x/translations/it.json
@@ -171,6 +171,15 @@
       },
       "outdoor_temperature": { "name": "Temperatura esterna" },
       "solar_intensity": { "name": "Intensità solare" },
+      "dhw_state": {
+        "name": "Stato acqua calda",
+        "state": {
+          "OFF": "Spento",
+          "SCHEDULE_OFF": "Programmazione spenta",
+          "SCHEDULE_ON": "Programmazione accesa",
+          "BOOST": "Boost"
+        }
+      },
       "weather_state": {
         "name": "Stato meteo",
         "state": {

--- a/custom_components/tado_x/translations/it.json
+++ b/custom_components/tado_x/translations/it.json
@@ -223,7 +223,10 @@
     "button": {
       "boost_all": { "name": "Boost globale" },
       "disable_all": { "name": "Spegni tutto" },
-      "resume_schedules": { "name": "Riprendi programmazioni" }
+      "resume_schedules": { "name": "Riprendi programmazioni" },
+      "boost_hot_water": { "name": "Boost L'acqua calda" },
+      "disable_hot_water": { "name": "Spegni l'acqua calda" },
+      "resume_hot_water_schedule": {"name": "Riprendi l'acqua calda programmazioni"}
     },
     "device_tracker": {
       "mobile_device": {


### PR DESCRIPTION
This pr addresses #50 and adds buttons to boost, disable and resume the schedule for domestic hot water.

The change also adds a sensor entity to show the state of the DHW on tado's API. 
This has been implemented as a text sensor rather than a binary sensor as the tado API has 4 states for the DHW (OFF, BOOSTING, SCHEDULE_HEATING, SCHEDULE_OFF).

Additionally a confg flag for the integration has been added to disable the domestic hot water feature if not using it. This config flag will also enable and disable the related sensors when toggled.

_Note: the API implementation on the tado side for turning off the hot water is a bit misleading.
Updating the BOOST function to off actually seems to turn off the DHW rather than cancel the boost. Resume schedule puts it back into schedule mode._