### PR TITLE
Feature: Termination type configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ A Home Assistant custom integration for **Tado X** devices (the new generation o
 | **Switches** | **Child lock** (per device), **Open window** control (per room) |
 | **Buttons** | **Boost All**, **Turn Off All**, **Resume Schedules** (quick actions) |
 | **Device Tracker** | **Mobile devices** for geofencing (home/away status) |
+| **Number** | **Timer duration** (per room default for manual temperature overrides) |
+| **Select** | **Termination type** (per room default: TIMER, MANUAL, NEXT_TIME_BLOCK) |
 | **Services** | Temperature offset, Meter reading, **Energy tariff** (Energy IQ) |
 
 ### Climate Presets
@@ -49,28 +51,6 @@ A Home Assistant custom integration for **Tado X** devices (the new generation o
 - **Home**: Manually set presence to Home (override geofencing)
 - **Away**: Manually set presence to Away (override geofencing)
 - **Auto (Geofencing)**: Enable automatic presence detection
-
-### Climate Temperature Control (Advanced)
-
-When calling Home Assistant's `climate.set_temperature` on a Tado X climate entity, you can now pass these optional fields:
-
-- **termination_type**: How long the manual override should stay active.
-  - `TIMER` (default): Override expires after `duration`
-  - `MANUAL`: Override stays active until manually changed
-  - `NEXT_TIME_BLOCK`: Override lasts until the next schedule block
-- **duration**: Override duration in minutes when `termination_type: TIMER` is used (default: `30`)
-
-Example:
-
-```yaml
-service: climate.set_temperature
-target:
-  entity_id: climate.living_room
-data:
-  temperature: 21.5
-  termination_type: TIMER
-  duration: 30
-```
 
 ### Quick Actions (Buttons)
 
@@ -88,6 +68,13 @@ Home-level controls for managing all zones at once:
   - Define tariff periods with start/end dates
   - Enables accurate cost tracking in Tado's Energy IQ dashboard
 - **set_climate_timer**: Set room temperature with optional termination_type (TIMER, MANUAL, NEXT_TIME_BLOCK)
+
+### Per-Room Default Controls
+
+These config entities let you set defaults used by the standard climate UI when it does not provide custom parameters:
+
+- **Timer Duration (number)**: Default duration (minutes) for manual temperature overrides
+- **Termination Type (select)**: Default termination type for manual overrides
 
 ### API Usage Monitoring
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Home-level controls for managing all zones at once:
   - Supports both m³ (gas) and kWh (electricity) units
   - Define tariff periods with start/end dates
   - Enables accurate cost tracking in Tado's Energy IQ dashboard
+- **set_climate_timer**: Set room temperature with optional termination_type (TIMER, MANUAL, NEXT_TIME_BLOCK)
 
 ### API Usage Monitoring
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ A Home Assistant custom integration for **Tado X** devices (the new generation o
 - **Away**: Manually set presence to Away (override geofencing)
 - **Auto (Geofencing)**: Enable automatic presence detection
 
+### Climate Temperature Control (Advanced)
+
+When calling Home Assistant's `climate.set_temperature` on a Tado X climate entity, you can now pass these optional fields:
+
+- **termination_type**: How long the manual override should stay active.
+  - `TIMER` (default): Override expires after `duration`
+  - `MANUAL`: Override stays active until manually changed
+  - `NEXT_TIME_BLOCK`: Override lasts until the next schedule block
+- **duration**: Override duration in minutes when `termination_type: TIMER` is used (default: `30`)
+
+Example:
+
+```yaml
+service: climate.set_temperature
+target:
+  entity_id: climate.living_room
+data:
+  temperature: 21.5
+  termination_type: TIMER
+  duration: 30
+```
+
 ### Quick Actions (Buttons)
 
 Home-level controls for managing all zones at once:

--- a/custom_components/tado_x/climate.py
+++ b/custom_components/tado_x/climate.py
@@ -259,8 +259,9 @@ class TadoXClimate(CoordinatorEntity[TadoXDataUpdateCoordinator], ClimateEntity)
         if temperature is None:
             return
 
-        termination_type = kwargs.get("termination_type", TERMINATION_TIMER)
-        duration_minutes = kwargs.get("duration", DEFAULT_TIMER_DURATION_MINUTES)
+        defaults = self.coordinator.get_room_control_defaults(self._room_id)
+        termination_type = kwargs.get("termination_type", defaults.termination_type)
+        duration_minutes = kwargs.get("duration", defaults.duration_minutes)
 
         await self.coordinator.api.set_room_temperature(
             self._room_id,

--- a/custom_components/tado_x/climate.py
+++ b/custom_components/tado_x/climate.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    DEFAULT_TIMER_DURATION,
+    DEFAULT_TIMER_DURATION_MINUTES,
     DOMAIN,
     MAX_TEMP,
     MIN_TEMP,
@@ -259,11 +259,14 @@ class TadoXClimate(CoordinatorEntity[TadoXDataUpdateCoordinator], ClimateEntity)
         if temperature is None:
             return
 
+        termination_type = kwargs.get("termination_type", TERMINATION_TIMER)
+        duration_minutes = kwargs.get("duration", DEFAULT_TIMER_DURATION_MINUTES)
+
         await self.coordinator.api.set_room_temperature(
             self._room_id,
             temperature=temperature,
-            termination_type=TERMINATION_TIMER,
-            duration_seconds=DEFAULT_TIMER_DURATION,
+            termination_type=termination_type,
+            duration_seconds=duration_minutes * 60,
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -61,7 +61,7 @@ TERMINATION_TIMER: Final = "TIMER"
 TERMINATION_NEXT_TIME_BLOCK: Final = "NEXT_TIME_BLOCK"
 
 # Default timer duration (30 minutes)
-DEFAULT_TIMER_DURATION: Final = 1800
+DEFAULT_TIMER_DURATION_MINUTES: Final = 30
 
 # Temperature limits
 MIN_TEMP: Final = 5.0

--- a/custom_components/tado_x/number.py
+++ b/custom_components/tado_x/number.py
@@ -5,13 +5,14 @@ import logging
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DEFAULT_TIMER_DURATION_MINUTES, DOMAIN
 from .coordinator import TadoXDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,6 +27,10 @@ async def async_setup_entry(
     coordinator: TadoXDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities: list[NumberEntity] = []
+
+    if coordinator.data:
+        for room_id in coordinator.data.rooms:
+            entities.append(TadoXRoomTimerDuration(coordinator, room_id))
 
     # Only add flow temperature if the feature is available
     if coordinator.data and coordinator.data.has_flow_temp_control:
@@ -102,4 +107,76 @@ class TadoXMaxFlowTemperature(CoordinatorEntity[TadoXDataUpdateCoordinator], Num
                 self._attr_native_min_value = float(data.flow_temp_min)
             if data.flow_temp_max is not None:
                 self._attr_native_max_value = float(data.flow_temp_max)
+        self.async_write_ha_state()
+
+
+class TadoXRoomTimerDuration(
+    CoordinatorEntity[TadoXDataUpdateCoordinator],
+    RestoreEntity,
+    NumberEntity,
+):
+    """Number entity for per-room timer duration default."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "timer_duration"
+    _attr_icon = "mdi:timer-outline"
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = 1.0
+    _attr_native_max_value = 1440.0
+    _attr_native_step = 1.0
+
+    def __init__(self, coordinator: TadoXDataUpdateCoordinator, room_id: int) -> None:
+        """Initialize the room timer duration entity."""
+        super().__init__(coordinator)
+        self._room_id = room_id
+        self._attr_unique_id = f"{coordinator.home_id}_{room_id}_timer_duration"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        room = self.coordinator.data.rooms.get(self._room_id) if self.coordinator.data else None
+        room_name = room.name if room else f"Room {self._room_id}"
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self.coordinator.home_id}_{self._room_id}")},
+            name=room_name,
+            manufacturer="Tado",
+            model="Tado X Room",
+            via_device=(DOMAIN, str(self.coordinator.home_id)),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        data = self.coordinator.data
+        return data is not None and self._room_id in data.rooms
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current default duration in minutes."""
+        defaults = self.coordinator.get_room_control_defaults(self._room_id)
+        return float(defaults.duration_minutes)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the default duration in minutes."""
+        duration_minutes = int(value)
+        self.coordinator.set_room_control_defaults(
+            self._room_id, duration_minutes=duration_minutes
+        )
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last value if available."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (None, "unknown", "unavailable"):
+            try:
+                restored = int(float(last_state.state))
+            except ValueError:
+                return
+            if restored != DEFAULT_TIMER_DURATION_MINUTES:
+                self.coordinator.set_room_control_defaults(
+                    self._room_id, duration_minutes=restored
+                )
         self.async_write_ha_state()

--- a/custom_components/tado_x/select.py
+++ b/custom_components/tado_x/select.py
@@ -7,11 +7,12 @@ from typing import Any
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, TERMINATION_MANUAL, TERMINATION_NEXT_TIME_BLOCK, TERMINATION_TIMER
 from .coordinator import TadoXDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +23,12 @@ PRESENCE_AWAY = "away"
 PRESENCE_AUTO = "auto"
 
 PRESENCE_OPTIONS = [PRESENCE_HOME, PRESENCE_AWAY, PRESENCE_AUTO]
+
+TERMINATION_OPTIONS = [
+    TERMINATION_TIMER,
+    TERMINATION_MANUAL,
+    TERMINATION_NEXT_TIME_BLOCK,
+]
 
 
 async def async_setup_entry(
@@ -35,6 +42,10 @@ async def async_setup_entry(
     entities: list[SelectEntity] = [
         TadoXPresenceSelect(coordinator),
     ]
+
+    if coordinator.data:
+        for room_id in coordinator.data.rooms:
+            entities.append(TadoXRoomTerminationType(coordinator, room_id))
 
     async_add_entities(entities)
 
@@ -97,4 +108,66 @@ class TadoXPresenceSelect(CoordinatorEntity[TadoXDataUpdateCoordinator], SelectE
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class TadoXRoomTerminationType(
+    CoordinatorEntity[TadoXDataUpdateCoordinator],
+    RestoreEntity,
+    SelectEntity,
+):
+    """Select entity for per-room termination type default."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "termination_type"
+    _attr_icon = "mdi:timer-cog-outline"
+    _attr_options = TERMINATION_OPTIONS
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: TadoXDataUpdateCoordinator, room_id: int) -> None:
+        """Initialize the room termination type entity."""
+        super().__init__(coordinator)
+        self._room_id = room_id
+        self._attr_unique_id = f"{coordinator.home_id}_{room_id}_termination_type"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        room = self.coordinator.data.rooms.get(self._room_id) if self.coordinator.data else None
+        room_name = room.name if room else f"Room {self._room_id}"
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self.coordinator.home_id}_{self._room_id}")},
+            name=room_name,
+            manufacturer="Tado",
+            model="Tado X Room",
+            via_device=(DOMAIN, str(self.coordinator.home_id)),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        data = self.coordinator.data
+        return data is not None and self._room_id in data.rooms
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current termination type."""
+        defaults = self.coordinator.get_room_control_defaults(self._room_id)
+        return defaults.termination_type
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the termination type."""
+        self.coordinator.set_room_control_defaults(
+            self._room_id, termination_type=option
+        )
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last option if available."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state in TERMINATION_OPTIONS:
+            self.coordinator.set_room_control_defaults(
+                self._room_id, termination_type=last_state.state
+            )
         self.async_write_ha_state()

--- a/custom_components/tado_x/services.yaml
+++ b/custom_components/tado_x/services.yaml
@@ -90,10 +90,6 @@ set_eiq_tariff:
 set_climate_timer:
   name: Set climate timer
   description: Set a room temperature for a specific duration. Useful for temporary overrides like a quick boost or extending heating.
-  target:
-    entity:
-      integration: tado_x
-      domain: climate
   fields:
     entity_id:
       name: Climate entity

--- a/custom_components/tado_x/services.yaml
+++ b/custom_components/tado_x/services.yaml
@@ -126,3 +126,18 @@ set_climate_timer:
           max: 1440
           step: 1
           unit_of_measurement: "min"
+    termination_type:
+      name: Termination type
+      description: How long the override should stay active
+      required: false
+      default: "TIMER"
+      example: "TIMER"
+      selector:
+        select:
+          options:
+            - label: "Timer"
+              value: "TIMER"
+            - label: "Manual"
+              value: "MANUAL"
+            - label: "Next time block"
+              value: "NEXT_TIME_BLOCK"

--- a/custom_components/tado_x/strings.json
+++ b/custom_components/tado_x/strings.json
@@ -282,6 +282,9 @@
     "number": {
       "max_flow_temperature": {
         "name": "Max Flow Temperature"
+      },
+      "timer_duration": {
+        "name": "Timer Duration"
       }
     },
     "button": {
@@ -302,6 +305,14 @@
           "home": "Home",
           "away": "Away",
           "auto": "Auto (Geofencing)"
+        }
+      },
+      "termination_type": {
+        "name": "Termination Type",
+        "state": {
+          "TIMER": "Timer",
+          "MANUAL": "Manual",
+          "NEXT_TIME_BLOCK": "Next Time Block"
         }
       }
     },

--- a/custom_components/tado_x/translations/de.json
+++ b/custom_components/tado_x/translations/de.json
@@ -262,6 +262,27 @@
     "number": {
       "max_flow_temperature": {
         "name": "Max. Vorlauftemperatur"
+      },
+      "timer_duration": {
+        "name": "Timerdauer"
+      }
+    },
+    "select": {
+      "presence_mode": {
+        "name": "Anwesenheitsmodus",
+        "state": {
+          "home": "Zuhause",
+          "away": "Unterwegs",
+          "auto": "Auto (Geofencing)"
+        }
+      },
+      "termination_type": {
+        "name": "Abschaltart",
+        "state": {
+          "TIMER": "Timer",
+          "MANUAL": "Manuell",
+          "NEXT_TIME_BLOCK": "Nächster Zeitblock"
+        }
       }
     },
     "button": {

--- a/custom_components/tado_x/translations/en.json
+++ b/custom_components/tado_x/translations/en.json
@@ -273,6 +273,27 @@
     "number": {
       "max_flow_temperature": {
         "name": "Max Flow Temperature"
+      },
+      "timer_duration": {
+        "name": "Timer Duration"
+      }
+    },
+    "select": {
+      "presence_mode": {
+        "name": "Presence Mode",
+        "state": {
+          "home": "Home",
+          "away": "Away",
+          "auto": "Auto (Geofencing)"
+        }
+      },
+      "termination_type": {
+        "name": "Termination Type",
+        "state": {
+          "TIMER": "Timer",
+          "MANUAL": "Manual",
+          "NEXT_TIME_BLOCK": "Next Time Block"
+        }
       }
     },
     "device_tracker": {

--- a/custom_components/tado_x/translations/it.json
+++ b/custom_components/tado_x/translations/it.json
@@ -219,6 +219,26 @@
     },
     "number": {
       "max_flow_temperature": { "name": "Temperatura massima flusso" }
+      ,
+      "timer_duration": { "name": "Durata timer" }
+    },
+    "select": {
+      "presence_mode": {
+        "name": "Modalità presenza",
+        "state": {
+          "home": "Casa",
+          "away": "Fuori casa",
+          "auto": "Automatico (Geofencing)"
+        }
+      },
+      "termination_type": {
+        "name": "Tipo terminazione",
+        "state": {
+          "TIMER": "Timer",
+          "MANUAL": "Manuale",
+          "NEXT_TIME_BLOCK": "Prossimo blocco orario"
+        }
+      }
     },
     "button": {
       "boost_all": { "name": "Boost globale" },


### PR DESCRIPTION
I wanted to have the ability to configure the termination type. This provides two ways to do this:

1. Service: set_climate_timer
   * Added `termination_type`
   * Bugfix: Removed "target entity" from services.yaml, because the service is reading from data and not from target (`call.data[ATTR_ENTITY_ID]`). If there is a target section in the yaml file, this causes the HA visual editor to populate it automatically (which means there will be an error when editing it the second time).
<img src="https://github.com/user-attachments/assets/ab38048f-68fb-4b39-8e1c-7808c3cccc51" />


2. Added new default configuration per room (termination_type, duration). Doing it this way allows to continue to use the default HA climate control, but to be still able to control the behavior.
<img src="https://github.com/user-attachments/assets/265ad5d4-1e14-48b9-9d09-02aa04dced82" />

Feedback welcome, I can also split this up into separate PRs. Tested everything with HA 2026.1 and Tado X, and seems to be working well.

---
_Disclaimer: Created with the help of LLMs_