### PR TITLE
Add sensors to display the control_mode which has been added to the API

### DIFF
--- a/custom_components/tado_x/coordinator.py
+++ b/custom_components/tado_x/coordinator.py
@@ -32,6 +32,7 @@ class TadoXDevice:
     temperature_offset: float = 0.0
     mounting_state: str | None = None
     child_lock_enabled: bool = False
+    control_mode: str | None = None
     room_id: int | None = None
     room_name: str | None = None
 
@@ -329,6 +330,7 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
                         temperature_offset=device_data.get("temperatureOffset", 0.0),
                         mounting_state=device_data.get("mountingState"),
                         child_lock_enabled=device_data.get("childLockEnabled", False),
+                        control_mode=device_data.get("controlMode"),
                         room_id=room_id,
                         room_name=room.name,
                     )
@@ -374,6 +376,7 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
                     device_type=device_type,
                     firmware_version=device_data.get("firmwareVersion", ""),
                     connection_state=other_device_connection.get("state", "DISCONNECTED"),
+                    control_mode=device_data.get("controlMode"),
                     room_id=other_room_id,
                     room_name=other_room_name,
                 )

--- a/custom_components/tado_x/sensor.py
+++ b/custom_components/tado_x/sensor.py
@@ -155,6 +155,12 @@ DEVICE_SENSORS: tuple[TadoXDeviceSensorEntityDescription, ...] = (
         icon="mdi:thermometer-plus",
         value_fn=lambda device: device.temperature_offset,
     ),
+    TadoXDeviceSensorEntityDescription(
+        key="control_mode",
+        translation_key="control_mode",
+        icon="mdi:tune-variant",
+        value_fn=lambda device: device.control_mode,
+    ),
 )
 
 def _get_api_usage_percentage(data: TadoXData) -> float:
@@ -351,6 +357,9 @@ async def async_setup_entry(
                     continue
                 # Skip temperature offset for devices that don't support it (Bridge)
                 if description.key == "temperature_offset" and device.temperature_offset is None:
+                    continue
+                # Skip control mode for devices that don't expose it
+                if description.key == "control_mode" and not device.control_mode:
                     continue
                 entities.append(TadoXDeviceSensor(coordinator, device.serial_number, description))
 

--- a/custom_components/tado_x/strings.json
+++ b/custom_components/tado_x/strings.json
@@ -175,6 +175,15 @@
       "temperature_offset": {
         "name": "Temperature Offset"
       },
+      "control_mode": {
+        "name": "Control Mode",
+        "state": {
+          "GAS_BOILER": "Default (Gas Boiler)",
+          "UNDERFLOOR_HEATING": "Underfloor Heating",
+          "HEAT_PUMP": "Heat Pump",
+          "NO_TEMPERATURE_CONTROL": "On heat request, continuously on"
+        }
+      },
       "api_calls_today": {
         "name": "API calls today"
       },

--- a/custom_components/tado_x/translations/de.json
+++ b/custom_components/tado_x/translations/de.json
@@ -155,6 +155,15 @@
       "temperature_offset": {
         "name": "Temperatur-Offset"
       },
+      "control_mode": {
+        "name": "Steuerungsmodus",
+        "state": {
+          "GAS_BOILER": "Standard (Gaskessel)",
+          "UNDERFLOOR_HEATING": "Fußbodenheizung",
+          "HEAT_PUMP": "Wärmepumpe",
+          "NO_TEMPERATURE_CONTROL": "Bei Heizbedarf, dauerhaft ein"
+        }
+      },
       "api_calls_today": {
         "name": "API-Aufrufe heute"
       },

--- a/custom_components/tado_x/translations/en.json
+++ b/custom_components/tado_x/translations/en.json
@@ -155,6 +155,15 @@
       "temperature_offset": {
         "name": "Temperature Offset"
       },
+      "control_mode": {
+        "name": "Control Mode",
+        "state": {
+          "GAS_BOILER": "Default (Gas Boiler)",
+          "UNDERFLOOR_HEATING": "Underfloor Heating",
+          "HEAT_PUMP": "Heat Pump",
+          "NO_TEMPERATURE_CONTROL": "On heat request, continuously on"
+        }
+      },
       "api_calls_today": {
         "name": "API calls today"
       },

--- a/custom_components/tado_x/translations/it.json
+++ b/custom_components/tado_x/translations/it.json
@@ -143,6 +143,15 @@
       },
       "device_temperature": { "name": "Temperatura dispositivo" },
       "temperature_offset": { "name": "Offset temperatura" },
+      "control_mode": {
+        "name": "Modalità controllo",
+        "state": {
+          "GAS_BOILER": "Predefinito (Caldaia a gas)",
+          "UNDERFLOOR_HEATING": "Riscaldamento a pavimento",
+          "HEAT_PUMP": "Pompa di calore",
+          "NO_TEMPERATURE_CONTROL": "Su richiesta riscaldamento, sempre acceso"
+        }
+      },
       "api_calls_today": { "name": "Chiamate API oggi" },
       "api_quota_remaining": { "name": "Quota API rimanente" },
       "api_quota_limit": { "name": "Limite quota API" },


### PR DESCRIPTION
Adds sensors to display the current value of the control mode for thermostats which was recently added in tados API

https://www.reddit.com/r/tado/comments/1re9fpm/new_control_modes_for_tado_x_underfloor_heating/

<img width="346" height="107" alt="image" src="https://github.com/user-attachments/assets/d9606904-2fbb-4aa1-89e4-9b7ecf91e7d4" />
