### PR TITLE
Enable Tado X integration to get and set domestic hot water target temperature

### DIFF
--- a/custom_components/tado_x/api.py
+++ b/custom_components/tado_x/api.py
@@ -855,3 +855,44 @@ class TadoXApi:
             f"{TADO_HOPS_API_URL}/homes/{self._home_id}/settings/flowTemperatureOptimization",
             json_data={"autoAdaptation": {"enabled": enabled}},
         )
+
+    async def get_domestic_hot_water_state(self) -> dict[str, Any]:
+        """Get the status of domestic hot water.
+
+        Returns:
+            Status information including:
+            {
+                {
+                    "state": "MANUAL_ON",
+                    "nextStateChange": null,
+                    "setpoint": 48,
+                    "setpointConstraints": {
+                        "min": 30,
+                        "max": 60
+                    }
+                }
+            }
+        """
+        if not self._home_id:
+            raise TadoXApiError("Home ID not set")
+
+        result = await self._request(
+            "GET",
+            f"{TADO_HOPS_API_URL}/homes/{self._home_id}/programmer/domesticHotWater/state",
+        )
+        return result if isinstance(result, dict) else {}
+
+    async def set_domestic_hot_water_setpoint(self, temperature: int) -> None:
+        """Set the target temerature for the boiler.
+
+        Args:
+            temperature: Temperature in °C (typically 30-60, depends on constraints)
+        """
+        if not self._home_id:
+            raise TadoXApiError("Home ID not set")
+
+        await self._request(
+            "POST",
+            f"{TADO_HOPS_API_URL}/homes/{self._home_id}/programmer/domesticHotWater/manualControl",
+            json_data={"setpoint": temperature},
+        )

--- a/custom_components/tado_x/config_flow.py
+++ b/custom_components/tado_x/config_flow.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_ACCESS_TOKEN,
     CONF_ENABLE_AIR_COMFORT,
     CONF_ENABLE_FLOW_TEMP,
+    CONF_ENABLE_DHW,
     CONF_ENABLE_MOBILE_DEVICES,
     CONF_ENABLE_RUNNING_TIMES,
     CONF_ENABLE_WEATHER,
@@ -272,6 +273,7 @@ class TadoXOptionsFlow(OptionsFlow):
             enable_air_comfort = user_input.get(CONF_ENABLE_AIR_COMFORT, has_auto_assist)
             enable_running_times = user_input.get(CONF_ENABLE_RUNNING_TIMES, has_auto_assist)
             enable_flow_temp = user_input.get(CONF_ENABLE_FLOW_TEMP, has_auto_assist)
+            enable_dhw = user_input.get(CONF_ENABLE_DHW, has_auto_assist)
 
             # Determine scan interval: custom if set, otherwise based on tier
             if custom_interval and custom_interval > 0:
@@ -292,6 +294,7 @@ class TadoXOptionsFlow(OptionsFlow):
                 CONF_ENABLE_AIR_COMFORT: enable_air_comfort,
                 CONF_ENABLE_RUNNING_TIMES: enable_running_times,
                 CONF_ENABLE_FLOW_TEMP: enable_flow_temp,
+                CONF_ENABLE_DHW: enable_dhw,
             }
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
@@ -309,6 +312,7 @@ class TadoXOptionsFlow(OptionsFlow):
                 coordinator.enable_air_comfort = enable_air_comfort
                 coordinator.enable_running_times = enable_running_times
                 coordinator.enable_flow_temp = enable_flow_temp
+                coordinator.enable_dhw = enable_dhw
 
             return self.async_create_entry(title="", data={})
 
@@ -323,6 +327,7 @@ class TadoXOptionsFlow(OptionsFlow):
         current_enable_air_comfort = self.config_entry.data.get(CONF_ENABLE_AIR_COMFORT, default_features)
         current_enable_running_times = self.config_entry.data.get(CONF_ENABLE_RUNNING_TIMES, default_features)
         current_enable_flow_temp = self.config_entry.data.get(CONF_ENABLE_FLOW_TEMP, default_features)
+        current_enable_dhw = self.config_entry.data.get(CONF_ENABLE_DHW, default_features)
 
         # Suggested intervals based on tier
         default_interval = (
@@ -361,6 +366,10 @@ class TadoXOptionsFlow(OptionsFlow):
                     vol.Required(
                         CONF_ENABLE_FLOW_TEMP,
                         default=current_enable_flow_temp,
+                    ): bool,
+                    vol.Required(
+                        CONF_ENABLE_DHW,
+                        default=current_enable_dhw,
                     ): bool,
                 }
             ),

--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -44,6 +44,7 @@ CONF_ENABLE_MOBILE_DEVICES: Final = "enable_mobile_devices"
 CONF_ENABLE_AIR_COMFORT: Final = "enable_air_comfort"
 CONF_ENABLE_RUNNING_TIMES: Final = "enable_running_times"
 CONF_ENABLE_FLOW_TEMP: Final = "enable_flow_temp"
+CONF_ENABLE_DHW: Final = "enable_dhw"
 
 # Base API calls (required): get_rooms, get_rooms_and_devices, get_home_state
 API_CALLS_BASE: Final = 3

--- a/custom_components/tado_x/coordinator.py
+++ b/custom_components/tado_x/coordinator.py
@@ -125,6 +125,12 @@ class TadoXData:
     flow_temp_auto_adaptation: bool = False
     flow_temp_auto_value: int | None = None
     has_flow_temp_control: bool = False
+    # Domestic hot water
+    dhw_setpoint: int | None = None
+    dhw_min: int | None = None
+    dhw_max: int | None = None
+    dhw_state: str | None = None
+    has_dhw: bool = False
 
 
 class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
@@ -143,6 +149,7 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
         enable_air_comfort: bool = True,
         enable_running_times: bool = True,
         enable_flow_temp: bool = True,
+        enable_dhw: bool = True,
     ) -> None:
         """Initialize the coordinator."""
         # Determine scan interval based on subscription tier if not explicitly set
@@ -171,6 +178,7 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
         self.enable_air_comfort = enable_air_comfort
         self.enable_running_times = enable_running_times
         self.enable_flow_temp = enable_flow_temp
+        self.enable_dhw = enable_dhw
 
         _LOGGER.info(
             "Tado X coordinator initialized with %d second update interval (%s tier)",
@@ -178,8 +186,8 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
             "Auto-Assist" if api.has_auto_assist else "Free"
         )
         _LOGGER.info(
-            "Optional features - Weather: %s, Mobile devices: %s, Air comfort: %s, Running times: %s, Flow temp: %s",
-            enable_weather, enable_mobile_devices, enable_air_comfort, enable_running_times, enable_flow_temp
+            "Optional features - Weather: %s, Mobile devices: %s, Air comfort: %s, Running times: %s, Flow temp: %s, DHW: %s",
+            enable_weather, enable_mobile_devices, enable_air_comfort, enable_running_times, enable_flow_temp, enable_dhw
         )
 
     def update_scan_interval(self, new_interval: int) -> None:
@@ -199,6 +207,8 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
         if self.enable_air_comfort:
             calls += 1
         if self.enable_running_times:
+            calls += 1
+        if self.enable_dhw:
             calls += 1
         return calls
 
@@ -488,6 +498,28 @@ class TadoXDataUpdateCoordinator(DataUpdateCoordinator[TadoXData]):
                     # (requires OpenTherm-compatible boiler control device)
                     _LOGGER.debug("Flow temperature optimization not available: %s", err)
                     data.has_flow_temp_control = False
+
+            # Fetch domestic hot water state (if enabled)
+            if self.enable_dhw:
+                try:
+                    dhw_data = await self.api.get_domestic_hot_water_state()
+                    if dhw_data:
+                        data.has_dhw = True
+                        data.dhw_state = dhw_data.get("state")
+                        data.dhw_setpoint = dhw_data.get("setpoint")
+                        constraints = dhw_data.get("setpointConstraints") or {}
+                        data.dhw_min = constraints.get("min")
+                        data.dhw_max = constraints.get("max")
+                        _LOGGER.debug(
+                            "DHW state: %s, setpoint: %s°C (range %s-%s)",
+                            data.dhw_state,
+                            data.dhw_setpoint,
+                            data.dhw_min,
+                            data.dhw_max,
+                        )
+                except Exception as err:
+                    _LOGGER.debug("Domestic hot water state not available: %s", err)
+                    data.has_dhw = False
 
             # Populate API stats (prefer real values from headers when available)
             data.api_calls_today = self.api.api_calls_today

--- a/custom_components/tado_x/number.py
+++ b/custom_components/tado_x/number.py
@@ -31,6 +31,10 @@ async def async_setup_entry(
     if coordinator.data and coordinator.data.has_flow_temp_control:
         entities.append(TadoXMaxFlowTemperature(coordinator))
 
+    # Add domestic hot water setpoint if available
+    if coordinator.data and coordinator.data.has_dhw:
+        entities.append(TadoXDhwSetpoint(coordinator))
+
     async_add_entities(entities)
 
 
@@ -102,4 +106,75 @@ class TadoXMaxFlowTemperature(CoordinatorEntity[TadoXDataUpdateCoordinator], Num
                 self._attr_native_min_value = float(data.flow_temp_min)
             if data.flow_temp_max is not None:
                 self._attr_native_max_value = float(data.flow_temp_max)
+        self.async_write_ha_state()
+
+
+class TadoXDhwSetpoint(CoordinatorEntity[TadoXDataUpdateCoordinator], NumberEntity):
+    """Number entity for Tado X domestic hot water setpoint."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "domestic_hot_water_setpoint"
+    _attr_icon = "mdi:water-thermometer"
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(self, coordinator: TadoXDataUpdateCoordinator) -> None:
+        """Initialize the DHW setpoint entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.home_id}_dhw_setpoint"
+
+        # Set min/max from constraints
+        data = coordinator.data
+        if data:
+            self._attr_native_min_value = float(data.dhw_min or 30)
+            self._attr_native_max_value = float(data.dhw_max or 60)
+        else:
+            self._attr_native_min_value = 30.0
+            self._attr_native_max_value = 60.0
+        self._attr_native_step = 1.0
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the home."""
+        home_name = self.coordinator.home_name or f"Tado Home {self.coordinator.home_id}"
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self.coordinator.home_id))},
+            name=home_name,
+            manufacturer="Tado",
+            model="Tado X Home",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current DHW setpoint."""
+        data = self.coordinator.data
+        if not data or not data.has_dhw:
+            return None
+        return float(data.dhw_setpoint) if data.dhw_setpoint is not None else None
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        data = self.coordinator.data
+        return data is not None and data.has_dhw
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the DHW setpoint."""
+        try:
+            await self.coordinator.api.set_domestic_hot_water_setpoint(int(value))
+            await self.coordinator.async_request_refresh()
+            _LOGGER.info("Set DHW setpoint to %d°C", int(value))
+        except Exception as err:
+            _LOGGER.error("Failed to set DHW setpoint: %s", err)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        # Update min/max if constraints changed
+        data = self.coordinator.data
+        if data and data.has_dhw:
+            if data.dhw_min is not None:
+                self._attr_native_min_value = float(data.dhw_min)
+            if data.dhw_max is not None:
+                self._attr_native_max_value = float(data.dhw_max)
         self.async_write_ha_state()

--- a/custom_components/tado_x/strings.json
+++ b/custom_components/tado_x/strings.json
@@ -50,7 +50,8 @@
           "enable_mobile_devices": "Enable mobile device tracking",
           "enable_air_comfort": "Enable air comfort sensors",
           "enable_running_times": "Enable heating time sensors",
-          "enable_flow_temp": "Enable flow temperature control"
+          "enable_flow_temp": "Enable flow temperature control",
+          "enable_dhw": "Enable domestic hot water control"
         },
         "data_description": {
           "has_auto_assist": "Enable this if you have an Auto-Assist subscription. This will automatically adjust the update interval.",
@@ -59,7 +60,8 @@
           "enable_mobile_devices": "Enables device trackers for mobile phones with geofencing. Uses 1 API call per update.",
           "enable_air_comfort": "Enables air freshness and comfort level sensors per room. Uses 1 API call per update.",
           "enable_running_times": "Enables heating time today sensors per room. Uses 1 API call per update.",
-          "enable_flow_temp": "Enables max flow temperature slider and auto-adaptation switch (requires OpenTherm boiler). Uses 1 API call per update."
+          "enable_flow_temp": "Enables max flow temperature slider and auto-adaptation switch (requires OpenTherm boiler). Uses 1 API call per update.",
+          "enable_dhw": "Enables domestic hot water temperature control. Uses 1 API call per update."
         }
       }
     }
@@ -282,6 +284,9 @@
     "number": {
       "max_flow_temperature": {
         "name": "Max Flow Temperature"
+      },
+      "domestic_hot_water_setpoint": {
+        "name": "Domestic Hot Water Temperature"
       }
     },
     "button": {

--- a/custom_components/tado_x/translations/en.json
+++ b/custom_components/tado_x/translations/en.json
@@ -49,7 +49,9 @@
           "enable_weather": "Enable weather sensors",
           "enable_mobile_devices": "Enable mobile device tracking",
           "enable_air_comfort": "Enable air comfort sensors",
-          "enable_running_times": "Enable heating time sensors"
+          "enable_running_times": "Enable heating time sensors",
+          "enable_flow_temp": "Enable flow temperature control",
+          "enable_dhw": "Enable domestic hot water control"
         },
         "data_description": {
           "has_auto_assist": "Enable this if you have an Auto-Assist subscription. This will automatically adjust the update interval.",
@@ -57,7 +59,9 @@
           "enable_weather": "Enables outdoor temperature, solar intensity, and weather state sensors. Uses 1 API call per update.",
           "enable_mobile_devices": "Enables device trackers for mobile phones with geofencing. Uses 1 API call per update.",
           "enable_air_comfort": "Enables air freshness and comfort level sensors per room. Uses 1 API call per update.",
-          "enable_running_times": "Enables heating time today sensors per room. Uses 1 API call per update."
+          "enable_running_times": "Enables heating time today sensors per room. Uses 1 API call per update.",
+          "enable_flow_temp": "Enables max flow temperature slider and auto-adaptation switch (requires OpenTherm boiler). Uses 1 API call per update.",
+          "enable_dhw": "Enables domestic hot water temperature control. Uses 1 API call per update."
         }
       }
     }
@@ -273,6 +277,9 @@
     "number": {
       "max_flow_temperature": {
         "name": "Max Flow Temperature"
+      },
+      "domestic_hot_water_setpoint": {
+        "name": "Domestic Hot Water Temperature"
       }
     },
     "device_tracker": {


### PR DESCRIPTION
This change adds a new entity - **Domestic hot water temperature**. Changing the value will set target temperature for the boiler to heat the water.

Useful for water tanks with solar heating. HA may now decide whether to heat the water when the temperature drops below set threshold, or maybe wait for the solar heating when the weather is about to be nice and sunny.
Best used in cooperation with weather data and time plans.

Example: in the morning, when it's going to be sunny, set target water temperature to 25 degrees (effectively stopping the gas heater from heating DHW tank) and at 6 PM set it back to desired temperature - 50 or so. If the water was heated by the solar system, there's no need to start the gas heater, if the sun was not strong enough, heater will start its job.